### PR TITLE
Extend families task to list devices as well.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,15 +22,19 @@ task :families do
   root = Pathname(__FILE__).dirname
   path = root.join('vendor', 'ua-parser', 'test_resources')
 
-  browser_families = paths_to_familiies([
+  browser_families = paths_to_families([
     path.join('test_user_agent_parser.yaml'),
     path.join('firefox_user_agent_strings.yaml'),
     path.join('pgts_browser_list.yaml'),
   ])
 
-  os_families = paths_to_familiies([
+  os_families = paths_to_families([
     path.join('test_user_agent_parser_os.yaml'),
     path.join('additional_os_tests.yaml'),
+  ])
+
+  device_families = paths_to_families([
+    path.join('test_device.yaml'),
   ])
 
   puts "\n\nBrowser Families"
@@ -39,12 +43,16 @@ task :families do
   puts "\n\nOS Families"
   puts os_families.inspect
 
+  puts "\n\nDevice Families"
+  puts device_families.inspect
+
   puts "\n\n"
   puts "Browser Family Count: #{browser_families.size}"
   puts "OS Family Count: #{os_families.size}"
+  puts "Device Family Count: #{device_families.size}"
 end
 
-def paths_to_familiies(paths)
+def paths_to_families(paths)
   require 'yaml'
 
   families = []


### PR DESCRIPTION
Simple extension to the Rake task that listed browser and OS families to also list device families.
