### PR TITLE
use faster matching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,14 @@
 language: ruby
 rvm:
-  - 2.4.1
-  - 2.3.3
-  - 2.2.7
-  - 2.1.8
+  - 2.5.1
+  - 2.4.4
+  - 2.3.7
+  - 2.2.10
+  - 2.1.10
   - 2.0.0
   - 1.9.3
   - jruby-19mode
   - ruby-head
-  - jruby-9.1.8.0
+  - jruby-9.1.17.0
 before_install:
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,9 @@ rvm:
   - 2.1.10
   - 2.0.0
   - 1.9.3
-  - jruby-19mode
   - ruby-head
+  - jruby-19mode
   - jruby-9.1.17.0
+  - jruby-9.2.0.0
 before_install:
   - gem install bundler

--- a/lib/user_agent_parser/parser.rb
+++ b/lib/user_agent_parser/parser.rb
@@ -8,7 +8,6 @@ module UserAgentParser
     attr_reader :patterns_path
 
     def initialize(options = {})
-      @fast_match = Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
       @patterns_path = options[:patterns_path] || UserAgentParser::DefaultPatternsPath
       @ua_patterns, @os_patterns, @device_patterns = load_patterns(patterns_path)
     end
@@ -64,19 +63,24 @@ module UserAgentParser
       end
     end
 
-    def first_pattern_match(patterns, value)
-      patterns.each do |pattern|
-        if @fast_match
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.4.0')
+      def first_pattern_match(patterns, value)
+        patterns.each do |pattern|
           if pattern[:regex].match?(value)
             return [pattern, pattern[:regex].match(value)]
           end
-        else
+        end
+        nil
+      end
+    else
+      def first_pattern_match(patterns, value)
+        patterns.each do |pattern|
           if match = pattern[:regex].match(value)
             return [pattern, match]
           end
         end
+        nil
       end
-      nil
     end
 
     def user_agent_from_pattern_match(pattern, match, os = nil, device = nil)


### PR DESCRIPTION
Faster matching:

 * accessing Regexp using `patterns[:regex]` is slightly faster than `patterns['regex']` (0.05 performance increase),
 * Ruby 2.4.0 introduced `match?` for faster regular expression matching, using `match?` to verify regular expression and then calling `match` to return matches is faster than using `match` for every iteration (0.32 performance increase).

```
Warming up --------------------------------------
               match   125.000  i/100ms
              match?   166.000  i/100ms
Calculating -------------------------------------
               match      1.266k (± 2.1%) i/s -      6.375k in   5.037348s
              match?      1.729k (± 2.1%) i/s -      8.798k in   5.090618s

Comparison:
              match?:     1729.1 i/s
               match:     1266.1 i/s - 1.37x  slower
```