### PR TITLE
🚀 increase speed of user agent parsing logic 

### DIFF
--- a/lib/user_agent_parser.rb
+++ b/lib/user_agent_parser.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'user_agent_parser/patterns'
 require 'user_agent_parser/parser'
 require 'user_agent_parser/user_agent'
 require 'user_agent_parser/version'
@@ -7,8 +8,6 @@ require 'user_agent_parser/operating_system'
 require 'user_agent_parser/device'
 
 module UserAgentParser
-  DefaultPatternsPath = File.join(File.dirname(__FILE__), '../vendor/uap-core/regexes.yaml')
-
   # Parse the given +user_agent_string+, returning a +UserAgent+
   def self.parse(user_agent_string, options = {})
     Parser.new(options).parse(user_agent_string)

--- a/lib/user_agent_parser/patterns.rb
+++ b/lib/user_agent_parser/patterns.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'yaml'
+
+module UserAgentParser
+  class Patterns
+    @@default_path = File.join(File.dirname(__FILE__), '../../vendor/uap-core/regexes.yaml')
+
+    def initialize
+      @cache = {}
+      get() # warm the cache for the default patterns
+    end
+
+    def get(path = nil)
+      path = @@default_path if path.nil?
+      @cache[path] ||= load_and_parse(path)
+    end
+
+    private
+
+    def load_and_parse(path)
+      yml = YAML.load_file(path)
+
+      # Parse all the regexs
+      yml.each_pair do |_type, patterns|
+        patterns.each do |pattern|
+          pattern[:regex] = Regexp.new(pattern['regex'], pattern['regex_flag'] == 'i')
+        end
+      end
+
+      [yml['user_agent_parsers'], yml['os_parsers'], yml['device_parsers']]
+    end
+  end
+end

--- a/spec/patterns_spec.rb
+++ b/spec/patterns_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
+require 'yaml'
+require 'benchmark'
+
+describe UserAgentParser::Patterns do
+  describe '#get' do
+    describe 'with the default path' do
+      it 'is fast when instance is already initialized' do
+        patterns = UserAgentParser::Patterns.new
+
+        time = Measure.milliseconds_elapsed do
+          patterns.get
+        end
+
+        time.must_be_less_than(10)
+      end
+    end
+
+    describe 'with a custom path' do
+      def custom_patterns_path
+        File.join(File.dirname(__FILE__), 'custom_regexes.yaml')
+      end
+
+      it 'returns the data from the custom patterns file' do
+        result = UserAgentParser::Patterns.new.get(custom_patterns_path)
+        result.must_equal [
+          [
+            {
+              "regex"=>".*",
+              "family_replacement"=>"Custom browser",
+              "v1_replacement"=>"1",
+              "v2_replacement"=>"2",
+              "v3_replacement"=>"3",
+              "v4_replacement"=>"4",
+              :regex=>/.*/
+            }
+          ],
+          [{"regex"=>".*", "os_replacement"=>"Custom OS", "os_v1_replacement"=>"1", "os_v2_replacement"=>"2", :regex=>/.*/}],
+          [{"regex"=>".*", "device_replacement"=>"Custom device", :regex=>/.*/}]
+        ]
+      end
+
+      it 'is faster for subsequent calls with the same custom path' do
+        patterns = UserAgentParser::Patterns.new
+
+        first_time = Measure.milliseconds_elapsed do
+          patterns.get(custom_patterns_path)
+        end
+
+        second_time = Measure.milliseconds_elapsed do
+          patterns.get(custom_patterns_path)
+        end
+
+        delta = (first_time - second_time).abs
+        second_time.must_be_less_than(first_time)
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,5 +29,29 @@ module MiniTest
     end
 
     Object.infect_an_assertion :assert_test_case_property_equal, :must_equal_test_case_property
+
+    def assert_less_than(expected, actual)
+      assert(
+        actual < expected,
+        "expected #{actual} to be less than: #{expected}"
+      )
+    end
+
+    Object.infect_an_assertion :assert_less_than, :must_be_less_than
+
+    def assert_more_than(expected, actual)
+      assert(
+        actual > expected,
+        "expected #{actual} to be greater than: #{expected}"
+      )
+    end
+
+    Object.infect_an_assertion :assert_more_than, :must_be_more_than
+  end
+end
+
+module Measure
+  def self.milliseconds_elapsed(&block)
+    Benchmark.realtime(&block) * 1000
   end
 end


### PR DESCRIPTION
## What does this do

The gem now eagerly loads and parses the default useragent regexes and stores them in a cache for fast access when called for. It also caches any custom regex files by their path. 

For usecases where the user agent parsing logic is called many times this can result in extremely large performance gains, at the cost of initialization time.

## Motivation
At Shopify, we've been using [`browserslist-useragent`](https://www.npmjs.com/package/browserslist-useragent) for a few months to perform differential serving of assets depending on the incoming user agent of a request (serving a JS bundle with different levels of polyfills and babel compilation depending on the browser requesting our app).  We also wanted to extend the same feature to our Rails applications. To do so we adopted the [Ruby equivalent](https://rubygems.org/gems/browserslist_useragent).

Unfortunately, we quickly realized that doing so was adding up to _100ms_ per script tag. In some cases over half of our request time would end up coming from the `browserslist_useragent` gem, with the majority of that time spent in this library. To stem the bleeding we added some cacheing based on `user_agent`, but this only solves the problem for subsequent requests from identical consuming agents. 

## Possible alternatives
If performance degradation at initialization is a big enough issue then the cache [warming call](https://github.com/TheMallen/uap-ruby/blob/master/lib/user_agent_parser/patterns.rb#L11) in `patterns.rb` could be removed. This would mean the very first request in cases like the one we were experiencing at Shopify would still be degraded, but would solve the issue for all subsequent requests.