### PR TITLE
bump uap-core to 0.6.9

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -48,7 +48,7 @@ describe UserAgentParser::Cli do
       let(:options) { { format: '%n|%f|%v|%M|%m|%o' } }
 
       it 'returns string without versions' do
-        _(cli.run!).must_equal('Mobile Safari|Mobile Safari||||Other')
+        _(cli.run!).must_equal('Mobile Safari|Mobile Safari||||iOS')
       end
     end
   end


### PR DESCRIPTION
Closes https://github.com/ua-parser/uap-ruby/pull/55