### PR TITLE
Put default family string in constant

### DIFF
--- a/lib/user_agent_parser/device.rb
+++ b/lib/user_agent_parser/device.rb
@@ -2,12 +2,14 @@
 
 module UserAgentParser
   class Device
+    DEFAULT_FAMILY = 'Other'
+
     attr_reader :family, :model, :brand
 
     alias name family
 
     def initialize(family = nil, model = nil, brand = nil)
-      @family = family || 'Other'
+      @family = family || DEFAULT_FAMILY
       @model = model || @family
       @brand = brand
     end

--- a/lib/user_agent_parser/operating_system.rb
+++ b/lib/user_agent_parser/operating_system.rb
@@ -2,11 +2,13 @@
 
 module UserAgentParser
   class OperatingSystem
+    DEFAULT_FAMILY = 'Other'
+
     attr_reader :family, :version
 
     alias name family
 
-    def initialize(family = 'Other', version = nil)
+    def initialize(family = DEFAULT_FAMILY, version = nil)
       @family = family
       @version = version
     end

--- a/lib/user_agent_parser/user_agent.rb
+++ b/lib/user_agent_parser/user_agent.rb
@@ -2,12 +2,14 @@
 
 module UserAgentParser
   class UserAgent
+    DEFAULT_FAMILY = 'Other'
+
     attr_reader :family, :version, :os, :device
 
     alias name family
 
     def initialize(family = nil, version = nil, os = nil, device = nil)
-      @family = family || 'Other'
+      @family = family || DEFAULT_FAMILY
       @version = version
       @os = os
       @device = device


### PR DESCRIPTION
Put the default family name ("Other") in a constant, so comparing with this value can be done in a more robust way by a consumer of this library.