### PR TITLE
Make the gem searchable by 'useragent' keyword

### DIFF
--- a/user_agent_parser.gemspec
+++ b/user_agent_parser.gemspec
@@ -7,8 +7,11 @@ Gem::Specification.new do |gem|
   gem.authors     = 'Tim Lucas'
   gem.email       = 't@toolmantim.com'
   gem.homepage    = 'https://github.com/ua-parser/uap-ruby'
-  gem.summary     = "A simple, comprehensive Ruby gem for parsing user agent strings with the help of BrowserScope's UA database"
-  gem.description = gem.summary
+  gem.summary     = "Parsing user agent strings with the help of BrowserScope's UA database"
+  gem.description = <<~DESCRIPTION
+    A simple, comprehensive Ruby gem for parsing user agent strings
+    with the help of BrowserScope's UserAgent database
+  DESCRIPTION
   gem.license     = 'MIT'
   gem.executables = ['user_agent_parser']
 


### PR DESCRIPTION
Fixes #66 

Make sure `useragent` string without spaces is present in the gem description.