### PR TITLE
Make client version comparable

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ user_agent.version.major
 => "9"
 user_agent.version.minor
 => "0"
+user_agent.family == "IE" && user_agent.version >= "9"
+=> true
 operating_system = user_agent.os
 => #<UserAgentParser::OperatingSystem Windows Vista>
 operating_system.to_s

--- a/lib/user_agent_parser/version.rb
+++ b/lib/user_agent_parser/version.rb
@@ -1,10 +1,14 @@
 # frozen_string_literal: true
 
+require 'rubygems/version'
+
 module UserAgentParser
   class Version
+    include Comparable
+
     # Private: Regex used to split string version string into major, minor,
     # patch, and patch_minor.
-    SEGMENTS_REGEX = /\d+\-\d+|\d+[a-zA-Z]+$|\d+|[A-Za-z][0-9A-Za-z-]*$/
+    SEGMENTS_REGEX = /\d+\-\d+|\d+[a-zA-Z]+$|\d+|[A-Za-z][0-9A-Za-z-]*$/.freeze
 
     attr_reader :version
     alias to_s version
@@ -45,9 +49,10 @@ module UserAgentParser
         version == other.version
     end
 
-    alias == eql?
+    def <=>(other)
+      Gem::Version.new(version).<=>(Gem::Version.new(other.to_s))
+    end
 
-    # Private
     def segments
       @segments ||= version.scan(SEGMENTS_REGEX)
     end

--- a/spec/version_spec.rb
+++ b/spec/version_spec.rb
@@ -78,6 +78,84 @@ describe UserAgentParser::Version do
     end
   end
 
+  describe '#<=>' do
+    it 'accepts string for comparison' do
+      version = UserAgentParser::Version.new('1.2.3')
+
+      assert_operator version, :<, '1.2.4'
+      assert_operator version, :==, '1.2.3'
+      assert_operator version, :>, '1.2.2'
+    end
+
+    it 'accepts another instance of Version for comparison' do
+      version = UserAgentParser::Version.new('1.2.3')
+
+      assert_operator version, :>, UserAgentParser::Version.new('1.2.2')
+      assert_operator version, :==, UserAgentParser::Version.new('1.2.3')
+      assert_operator version, :<, UserAgentParser::Version.new('1.2.4')
+    end
+
+    it 'is comparing major version' do
+      version = UserAgentParser::Version.new('1.2.3')
+
+      assert_operator version, :<, '2'
+      assert_operator version, :>=, '1'
+      assert_operator version, :>, '0'
+    end
+
+    it 'is comparing minor version' do
+      version = UserAgentParser::Version.new('1.2.3')
+
+      assert_operator version, :<, '2.0'
+      assert_operator version, :<, '1.3'
+      assert_operator version, :>=, '1.2'
+      assert_operator version, :>, '1.1'
+      assert_operator version, :>, '0.1'
+    end
+
+    it 'is comparing patch level' do
+      version = UserAgentParser::Version.new('1.2.3')
+
+      assert_operator version, :<, '1.2.4'
+      assert_operator version, :>=, '1.2.3'
+      assert_operator version, :<=, '1.2.3'
+      assert_operator version, :>, '1.2.2'
+    end
+
+    it 'is comparing patch_minor level correctly' do
+      version = UserAgentParser::Version.new('1.2.3.p1')
+
+      assert_operator version, :<, '1.2.4'
+      assert_operator version, :<, '1.2.3.p2'
+      assert_operator version, :>=, '1.2.3.p1'
+      assert_operator version, :<=, '1.2.3.p1'
+      assert_operator version, :>, '1.2.3.p0'
+      assert_operator version, :>, '1.2.2'
+      assert_operator version, :>, '1.1'
+    end
+
+    it 'is correctly comparing versions with different lengths' do
+      version = UserAgentParser::Version.new('1.42.3')
+
+      assert_operator version, :<, '1.142'
+      assert_operator version, :<, '1.42.4'
+      assert_operator version, :>=, '1.42'
+      assert_operator version, :>, '1.14'
+      assert_operator version, :>, '1.7'
+      assert_operator version, :>, '1.3'
+    end
+
+    it 'does its best to compare string versions' do
+      version = UserAgentParser::Version.new('1.2.3.a')
+
+      assert_operator version, :<, '1.2.4'
+      assert_operator version, :<, '1.2.3.b'
+      assert_operator version, :<, '1.2.3.p1'
+      assert_operator version, :<, '1.2.3.p0'
+      assert_operator version, :>, '1.2.2'
+    end
+  end
+
   describe '#inspect' do
     it 'returns the class and version' do
       version = UserAgentParser::Version.new('1.2.3')


### PR DESCRIPTION
Allow comparing with string versions.
Matching versions with less precision will compare as true.

For example:
```
> user_agent = UserAgentParser.parse "Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G930T Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.0 Chrome/51.0.2704.106 Mobile Safari/537.36"
> user_agent.family
=> "Samsung Internet"
> user_agent.version
=> #<UserAgentParser::Version 5.0>
> user_agent.version >= "5"
=> true
> user_agent.version >= "5.1"
=> false
```