### PR TITLE
Support loading multiple databases files

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,11 @@ or when instantiating a `UserAgentParser::Parser`:
 UserAgentParser::Parser.new(patterns_path: '/some/path/to/regexes.yaml').parse(ua_string)
 ```
 
+Extending the standard database is possible by providing multiple files in `patterns_paths` (plural) array argument:
+```ruby
+UserAgentParser::Parser.new(patterns_paths: [UserAgentParser::DefaultPatternsPath, '/some/path/to/regexes.yaml'])
+```
+
 ## Command line tool
 
 The gem incldes a `user_agent_parser` bin command which will read from

--- a/lib/user_agent_parser.rb
+++ b/lib/user_agent_parser.rb
@@ -10,7 +10,7 @@ module UserAgentParser
   DefaultPatternsPath = File.join(File.dirname(__FILE__), '../vendor/uap-core/regexes.yaml')
 
   # Parse the given +user_agent_string+, returning a +UserAgent+
-  def self.parse(user_agent_string, options = {})
-    Parser.new(options).parse(user_agent_string)
+  def self.parse(user_agent_string, **args)
+    Parser.new(**args).parse(user_agent_string)
   end
 end

--- a/spec/other_regexes.yaml
+++ b/spec/other_regexes.yaml
@@ -1,17 +1,17 @@
 user_agent_parsers:
-  - regex: 'Any.*'
-    family_replacement: 'Custom browser'
+  - regex: 'Other.*'
+    family_replacement: 'Other browser'
     v1_replacement: '1'
     v2_replacement: '2'
     v3_replacement: '3'
     v4_replacement: '4'
 
 os_parsers:
-  - regex: 'Any.*'
-    os_replacement: 'Custom OS'
+  - regex: 'Other.*'
+    os_replacement: 'Other OS'
     os_v1_replacement: '1'
     os_v2_replacement: '2'
 
 device_parsers:
-  - regex: 'Any.*'
-    device_replacement: 'Custom device'
+  - regex: 'Other.*'
+    device_replacement: 'Other device'

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -57,6 +57,10 @@ describe UserAgentParser::Parser do
     File.join(File.dirname(__FILE__), 'custom_regexes.yaml')
   end
 
+  def other_patterns_path
+    File.join(File.dirname(__FILE__), 'other_regexes.yaml')
+  end
+
   describe '::parse' do
     it 'parses a UA' do
       ua = UserAgentParser.parse('Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/418.8 (KHTML, like Gecko) Safari/419.3')
@@ -69,9 +73,12 @@ describe UserAgentParser::Parser do
   end
 
   describe '#initialize with a custom patterns path' do
-    it 'uses the custom patterns' do
+    it 'accepts a single patterns_path string' do
       parser = UserAgentParser::Parser.new(patterns_path: custom_patterns_path)
       ua = parser.parse('Any user agent string')
+
+      _(parser.patterns_paths).must_equal([custom_patterns_path])
+      _(parser.patterns_path).must_equal(custom_patterns_path)
 
       _(ua.family).must_equal('Custom browser')
       _(ua.version.major).must_equal('1')
@@ -84,6 +91,20 @@ describe UserAgentParser::Parser do
       _(ua.os.version.minor).must_equal('2')
 
       _(ua.device.family).must_equal('Custom device')
+    end
+
+    it 'accepts patterns_paths array' do
+      patterns_paths = [custom_patterns_path, other_patterns_path]
+      parser = UserAgentParser::Parser.new(patterns_paths: patterns_paths)
+
+      _(parser.patterns_paths).must_equal(patterns_paths)
+      _(parser.patterns_path).must_equal(custom_patterns_path)
+
+      ua = parser.parse('Any user agent string')
+      oua = parser.parse('Other user agent string')
+
+      _(ua.family).must_equal('Custom browser')
+      _(oua.family).must_equal('Other browser')
     end
   end
 


### PR DESCRIPTION
 Allow passing multiple pattern databases as an array to the new `patterns_paths` argument

- Support `patterns_path` argument but deprecate `pattern_path` attribute accessor
- Add new `patterns_paths` array argument to enable loading multiple patterns files
- Use keyword arguments instead of options array
- Always use the faster match version since we already require ruby 2.4 in gemspec

Fixes #11

