### PR TITLE
updates-2021-11-02

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,25 +6,25 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    coveralls_reborn (0.20.0)
+    coveralls_reborn (0.23.0)
       simplecov (>= 0.18.1, < 0.22.0)
       term-ansicolor (~> 1.6)
       thor (>= 0.20.3, < 2.0)
       tins (~> 1.16)
-    docile (1.3.5)
-    minitest (5.14.3)
-    rake (13.0.3)
+    docile (1.4.0)
+    minitest (5.14.4)
+    rake (13.0.6)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
-    simplecov_json_formatter (0.1.2)
+    simplecov_json_formatter (0.1.3)
     sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     thor (1.1.0)
-    tins (1.28.0)
+    tins (1.29.1)
       sync
 
 PLATFORMS
@@ -38,4 +38,4 @@ DEPENDENCIES
   user_agent_parser!
 
 BUNDLED WITH
-   2.2.8
+   2.2.30


### PR DESCRIPTION
- update https://github.com/ua-parser/uap-core to `dfb67d2`
- bump gems